### PR TITLE
Remove native identity flags

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -26,8 +26,6 @@ function loadIntoWindow(window) {
     return;
 
   pref("dom.payment.skipHTTPSCheck", true);
-  pref("dom.identity.enabled", true);
-  pref("toolkit.identity.debug", true);
 
   pref("dom.payment.provider.1.name", "firefoxmarketdev");
   pref("dom.payment.provider.1.description", "marketplace-dev.allizom.org");
@@ -58,8 +56,6 @@ function unloadFromWindow(window) {
   if (!window)
     return;
   unpref("dom.payment.skipHTTPSCheck", true);
-  unpref("dom.identity.enabled", true);
-  unpref("toolkit.identity.debug", true);
 
   unpref("dom.payment.provider.1.name", "firefoxmarketdev");
   unpref("dom.payment.provider.1.description", "marketplace-dev.allizom.org");
@@ -95,10 +91,10 @@ var windowListener = {
       loadIntoWindow(domWindow);
     }, false);
   },
-  
+
   onCloseWindow: function(aWindow) {
   },
-  
+
   onWindowTitleChange: function(aWindow, aTitle) {
   }
 };


### PR DESCRIPTION
Firefox on Android doesn't have native identity
so these flags were only causing problems.
Example: https://bugzilla.mozilla.org/show_bug.cgi?id=939328
